### PR TITLE
remove requirement on a 'seal' directory

### DIFF
--- a/src/pair/alignment_matrix/memory_mapped.rs
+++ b/src/pair/alignment_matrix/memory_mapped.rs
@@ -26,7 +26,7 @@ impl AlignmentMatrixTrait for AlignmentMatrix {
 
     fn new(width: usize, height: usize) -> Result<Self, Self::Error> {
         let tempdir = tempdir()?;
-        let directory = tempdir.path().join("seal");
+        let directory = tempdir.path();
         let uuid = Uuid::new_v4();
         let filename = uuid.to_simple().to_string();
         let path = directory.join(filename);


### PR DESCRIPTION
Memory-mapped strategy was dependent on a directory named 'seal' which the script doesn't create, throwing an error when it doesn't exist. Since this is a temporary file anyway, the directory is unnecessary and it would likely be best to just remove it.